### PR TITLE
fix: slack channel name

### DIFF
--- a/.github/workflows/slack_pullrequest.yml
+++ b/.github/workflows/slack_pullrequest.yml
@@ -17,7 +17,6 @@ jobs:
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_WEBHOOK: ${{ secrets.PR_SLACK_WEBHOOK }}
-        SLACK_CHANNEL: pullrequest
         SLACK_COLOR: 'good'
         SLACK_ICON: ${{ github.event.pull_request.user.avatar_url }}
         SLACK_MESSAGE: ${{ github.event.pull_request.body }} - ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
channel name을 넣으면 github action에서 한번 더 검증을 하는것 같아서 채널명을 삭제